### PR TITLE
bound the while loops to prevent the gui from hanging

### DIFF
--- a/sabnzbd_unplugged.plg
+++ b/sabnzbd_unplugged.plg
@@ -126,15 +126,28 @@ sabnzbd_start()
 	
   if [ -f /mnt/cache/apps/sab/sabnzbd.ini ]; then
 		chmod 777 "/mnt/cache/apps/sab/sabnzbd.ini"
+		TIMER=0
 		HTTPS=`cat "/mnt/cache/apps/sab/sabnzbd.ini" | grep 'enable_https' | cut -d' ' -f3`
 			if [ $HTTPS = 0 ]; then
 				while [ ! -e /var/run/sabnzbd/sabnzbd-$PORT.pid  ]; do
 				sleep 1
+				let TIMER=$TIMER+1
+       				echo -n $TIMER
+       				if [ $TIMER -gt 10 ]; then
+        			        echo -n "transmission.pid not deleted for some reason"
+        			        break
+		        	fi
+				
 				done
 			elif [ $HTTPS = 1 ]; then
 				PORT=`cat "/mnt/cache/apps/sab/sabnzbd.ini" | grep 'https_port' | cut -d' ' -f3`
 				while [ ! -e /var/run/sabnzbd/sabnzbd-$PORT.pid  ]; do
 				sleep 1
+				let TIMER=$TIMER+1
+				if [ $TIMER -gt 10 ]; then
+					echo -n "transmission.pid not created for some reason"
+					break
+				fi
 				done
 			fi
 	fi

--- a/sickbeard_unplugged.plg
+++ b/sickbeard_unplugged.plg
@@ -113,8 +113,16 @@ sickbeard_start()
 	sleep 1
 	$CMDLINE
   
+	TIMER=0
 	while [ ! -e /var/run/sickbeard/sickbeard.pid ]; do
 		sleep 1
+		let TIMER=$TIMER+1
+	        echo -n $TIMER
+	        if [ $TIMER -gt 10 ]; then
+        	        echo -n "transmission.pid not deleted for some reason"
+                	break
+        	fi
+
 	done
 	echo "... OK"
 	sleep 1


### PR DESCRIPTION
If these while loops go unbounded, they can hang the webgui.  This is a temporary fix until someone has time to figure out why sometimes those *.pid files don't seem to be created causing the loops to continue looping in the first place.
