### PR TITLE
rework https enablement, port & pid checking logic

### DIFF
--- a/sabnzbd_unplugged.plg
+++ b/sabnzbd_unplugged.plg
@@ -147,7 +147,7 @@ sabnzbd_start()
 	fi
   
 	# no-op if already running
-	if [ -r /var/run/sabnzbd/sabnzbd-$PORT.pid ]; then
+	if [ -r /var/run/sabnzbd/sabnzbd-$PIDPORT.pid ]; then
 		return
 	fi
 
@@ -169,36 +169,21 @@ sabnzbd_start()
   if [ -f $DATADIR/sabnzbd.ini ]; then
 		chmod 777 "$DATADIR/sabnzbd.ini"
 		TIMER=0
-		HTTPS=`cat "$DATADIR/sabnzbd.ini" | grep 'enable_https' | cut -d' ' -f3`
-			if [ $HTTPS = 0 ]; then
-				while [ ! -e /var/run/sabnzbd/sabnzbd-$PORT.pid  ]; do
-				sleep 1
-				let TIMER=$TIMER+1
-       				echo -n $TIMER
-       				if [ $TIMER -gt 10 ]; then
-        			        echo -n "sabnzbd-$PORT.pid not created for some reason"
-        			        break
-		        	fi
-				
-				done
-			elif [ $HTTPS = 1 ]; then
-				PORT=`cat "$DATADIR/sabnzbd.ini" | grep 'https_port' | cut -d' ' -f3`
-				while [ ! -e /var/run/sabnzbd/sabnzbd-$PORT.pid  ]; do
-				sleep 1
-				let TIMER=$TIMER+1
-				if [ $TIMER -gt 10 ]; then
-					echo -n "sabnzbd-$PORT.pid not created for some reason"
-					break
-				fi
-				done
-			fi
+		while [ ! -e /var/run/sabnzbd/sabnzbd-$PIDPORT.pid  ]; do
+		sleep 1
+		let TIMER=$TIMER+1
+		if [ $TIMER -gt 10 ]; then
+		echo -n "sabnzbd-$PIDPORT.pid not created for some reason"
+		break
+		fi
+		done
 	fi
 }
 
 sabnzbd_stop()
 {
 	# no-op if not running
-	if [ ! -r /var/run/sabnzbd/sabnzbd-$PORT.pid ]; then
+	if [ ! -r /var/run/sabnzbd/sabnzbd-$PIDPORT.pid ]; then
 		return
 	fi
 	
@@ -210,16 +195,16 @@ sabnzbd_stop()
 		IP=$(ifconfig  | grep 'inet addr:' | grep -v '127.0.0.1' | cut -d: -f2 | grep -v '^5' | awk '{ print $1}')
 		RES=$(wget -qO - "http://$IP:$PORT/sabnzbd/api?mode=shutdown&apikey=$APIKEY")
 		if [[ $RES != "ok" ]]; then
-			kill $(cat /var/run/sabnzbd/sabnzbd-$PORT.pid)
+			kill $(cat /var/run/sabnzbd/sabnzbd-$PIDPORT.pid)
 		fi
 	else
-		kill $(cat /var/run/sabnzbd/sabnzbd-$PORT.pid)
+		kill $(cat /var/run/sabnzbd/sabnzbd-$PIDPORT.pid)
 	fi
 	sleep 3
 
-	if [ -e /var/run/sabnzbd/sabnzbd-$PORT.pid ]; then
-		kill -9 $(cat /var/run/sabnzbd/sabnzbd-$PORT.pid )
-		rm /var/run/sabnzbd/sabnzbd-$PORT.pid
+	if [ -e /var/run/sabnzbd/sabnzbd-$PIDPORT.pid ]; then
+		kill -9 $(cat /var/run/sabnzbd/sabnzbd-$PIDPORT.pid )
+		rm /var/run/sabnzbd/sabnzbd-$PIDPORT.pid
 	fi
 	echo "... OK"
 	sleep 1
@@ -459,10 +444,20 @@ sabnzbd_newver()
 source /boot/config/plugins/sabnzbd/sabnzbd.cfg
 if [ -e $DATADIR/sabnzbd.ini ]; then
 	PORT=`cat "$DATADIR/sabnzbd.ini" | grep '^port' | awk 'NR==1' | cut -d' ' -f3 | tr -d '\r'`
+	HTTPS=`cat "$DATADIR/sabnzbd.ini" | grep 'enable_https =' | cut -d' ' -f3`
+	HTTPS_PORT=`cat "$DATADIR/sabnzbd.ini" | grep 'https_port =' | cut -d' ' -f3`
 else
 	PORT=`cat /boot/config/plugins/sabnzbd/sabnzbd.ini | grep '^port' | awk 'NR==1' | cut -d' ' -f3 | tr -d '\r'`
 fi
-
+if [ $HTTPS = "1" ]; then  #is https enabled?
+  if [ $HTTPS_PORT = "\"\"" ]; then  #is https port empty
+    PIDPORT=$PORT  #assign regular port as https will run using regular port and created pid  will use regular port value
+  else
+    PIDPORT=$HTTPS_PORT  #https port contains value, set pidport as created pid  will use https port value
+  fi
+else
+  PIDPORT=$PORT  #not using https, set pidport to be value of http port
+fi
 case "$1" in
 	'start')
 		sabnzbd_start
@@ -548,16 +543,31 @@ $sabnzbd_installed = file_exists( $sabnzbd_cfg["INSTALLDIR"] . "/SABnzbd.py" ) ?
 $sabnzbd_rollback = file_exists( "boot/config/plugins/sabnzbd_unplugged.plg.old" ) ? "yes" : "no";
 $sabnzbd_plgver = shell_exec ( "cat /boot/config/plugins/sabnzbd/plgver.txt" );
 $sabnzbd_configfile = $sabnzbd_cfg["DATADIR"] . "/sabnzbd.ini";
-if (file_exists("$sabnzbd_configfile"))
-$https = trim(shell_exec( "cat \"$sabnzbd_configfile\" | grep 'enable_https =' | cut -d' ' -f3" ));
+if (file_exists("$sabnzbd_configfile")) {
+  //setup vars for later to decide whether https is enabled.  this also takes account for condition where https is enabled but user
+  //has not supplied a value in http_port.  SAB allows this and if https_port is empty, it uses the value in port instead.  so here
+  //we check for empty http_port and assign it regular port if empty.  make for easier checking below.
+  $https = trim(shell_exec( "cat \"$sabnzbd_configfile\" | grep 'enable_https =' | cut -d' ' -f3" ));
+  $sab_port = trim(shell_exec( "cat \"$sabnzbd_configfile\" | grep '^port' | awk 'NR==1' | cut -d' ' -f3" ));
+  $https_port = trim(shell_exec( "cat \"$sabnzbd_configfile\" | grep 'https_port =' | cut -d' ' -f3" ));
+  if ($https_port == "\"\"") {
+    $https_port = $sab_port;
+  }
+}
 if ($sabnzbd_installed=="yes") 
 {
+	// NB. sabnzbd's pid file contains either regular port or https port depending on whether https enabled or disabled
 	if( (file_exists("$sabnzbd_configfile")) && ($https=="1")) {
-		$sab_port = trim(shell_exec( "cat \"$sabnzbd_configfile\" | grep 'https_port =' | cut -d' ' -f3" ));
+	    // https is enabled, so we have to get the value of https_port, but we can't assume a value in this field so instead of
+		// getting the value from the ini file, use what we have already defined above.  by now $https_port will either have its
+		// own value or if empty assigned the value in regular field.  so go ahead and set $sab_port to $https_port
+		//$sab_port = $https_port;
+		$sabnzbd_running = file_exists( "/var/run/sabnzbd/sabnzbd-".$https_port.".pid") ? "yes" : "no";	
 	} else { 
-		$sab_port = trim(shell_exec( "cat \"$sabnzbd_configfile\" | grep '^port' | awk 'NR==1' | cut -d' ' -f3" ));
+        // https is disabled, so infer running from port value in regular port ini field	
+		// $sab_port = trim(shell_exec( "cat \"$sabnzbd_configfile\" | grep '^port' | awk 'NR==1' | cut -d' ' -f3" ));
+		$sabnzbd_running = file_exists( "/var/run/sabnzbd/sabnzbd-".$sab_port.".pid") ? "yes" : "no";	
 			}
-	$sabnzbd_running = file_exists( "/var/run/sabnzbd/sabnzbd-".$sab_port.".pid") ? "yes" : "no";
 			
 	if ($sabnzbd_cfg[PLG_STORAGESIZE]=="yes") {
 		$sabnzbd_datasize = shell_exec ( "/etc/rc.d/rc.sabnzbd storagesize $sabnzbd_cfg[INSTALLDIR] $sabnzbd_cfg[DATADIR]" );
@@ -701,6 +711,25 @@ if ($sabnzbd_installed=="yes")
 				<td>Port:</td>
 				<td><input type="text" name="arg3" maxlength="40" value="<?=$sab_port;?>"></td>
 			</tr>
+		    <!--display https port in gui only if 
+			1) https is enabled, 
+			2) https port is different than regular port.  eg. user has specifically put in a value to the https port in sab gui
+			3) https port value contains a value as opposed to being left empty (meaning sab uses https over value in regular port field).  sab ini file has "" when value empty, so check needs to look for "" as actual value
+            
+			this way user can see via webgui whether https is enabled and if so what port.  the only issue with this is that webgui will 
+			show only "HTTP Port" field entry when user has a) enabled HTTPS + b) has blank value in https_port, and user could take that
+			to mean HTTPs is not enabled when in fact sab is using the port in HTTP field as HTTPS.  Ideally should also contexually
+			change the wording on HTTP Port form field to say HTTPS under these conditions.  But is it really necessary?
+			
+			NB: https port form field should probably be readonly. value taken from sab ini file and set via sab gui.
+			
+			-->
+			<?if (($https=="1") && ($https_port != $sab_port) && ($https_port != "\"\"")):?>
+			<tr>
+			  <td>HTTPS Port:</td>
+			  <td><input type="text" name="arg8" maxlength="40" value="<?=$https_port;?>"></td>
+			</tr>
+		    <?endif;?>	
 			<tr>
 				<td>Run as user:</td>
 				<td>

--- a/sabnzbd_unplugged.plg
+++ b/sabnzbd_unplugged.plg
@@ -727,7 +727,7 @@ if ($sabnzbd_installed=="yes")
 			<?if (($https=="1") && ($https_port != $sab_port) && ($https_port != "\"\"")):?>
 			<tr>
 			  <td>HTTPS Port:</td>
-			  <td><input type="text" name="arg8" maxlength="40" value="<?=$https_port;?>"></td>
+			  <td><input type="text" name="arg9" maxlength="40" value="<?=$https_port;?>"></td>
 			</tr>
 		    <?endif;?>	
 			<tr>


### PR DESCRIPTION
Revised how rc.sabnzbd and sabnzbd.php determines when https is enabled and what port to use in that situation. 

This pull request tries to resolve the following issue;

rc.sabnzbd assumes if https is enabled, then there will be a value in https_port.  This is not always the case as it is possible for sabnzbd to have this field blank where it will use HTTPS over the value in regular port ini entry.  The current logic is not sufficient to account for all eventualties.

sabnzbd.php has been amended to include additional logic for how to determine if sabnzbd is running based on whether https is enabled and what port is in use.

An additional form field has been contextually added to show when HTTPS is enabled and https_port contains a value.

There are still some gaps in the logic:

1) php form field "HTTPS Port" will only be displayed in the webgui when https is enabled and https_port  contains a value different than that in port.  For form field exists solely to be informative to the user.  There exists a scenario where https is enabled but https_port field is empty, thus using HTTPS over value stored in regular port.  Using current logic, "HTTPS Port" form field will not display under these circumstances, meaning that webgui will show "HTTP Port" and whilst the value in this field is accurate, SAB is actually using HTTPS over this port.  This could lead to user confusion.  Perhaps it is best to hide the HTTPS port value at all times. Or add an extra contextual change so that "HTTP Port" form field becomes "HTTPS Port" when https is enabled but https_port has no value.

2) Changing HTTPS config from inside SABnzbd webgui can lead to issues in the plugin. The user always has the option to make changes within SABnzbd and hit the built-in restart button.  This can cause the rc.script and php file to get out of sync such as the script may try to stop an existing instance of SAB but against the wrong port and/or php file wrongly detects SAB as running/not running.

However, I think the included changes go some way to ensuring both HTTP and HTTP ports are managed correctly.
