### PR TITLE
move config file creation above checkconfig in plg

### DIFF
--- a/sabnzbd_unplugged.plg
+++ b/sabnzbd_unplugged.plg
@@ -75,6 +75,21 @@ rm /tmp/sabnzbd-cleanup
 </INLINE>
 </FILE>
 
+<FILE Name="/boot/config/plugins/sabnzbd/sabnzbd.cfg">
+<INLINE>
+<![CDATA[
+# SABnzbd configuration:
+SERVICE="disable"
+BETA="no"
+INSTALLDIR="/usr/local/sabnzbd"
+DATADIR="/usr/local/sabnzbd"
+RUNAS="nobody"
+PLG_STORAGESIZE="yes"
+PLG_DATACHECK="yes"
+]]>
+</INLINE>
+</FILE>
+
 <FILE Name="/tmp/checkconfig" Run="/bin/bash">
 <INLINE>
 <![CDATA[
@@ -93,21 +108,6 @@ rm /tmp/checkconfig
 <INLINE>
 <![CDATA[
 2.4
-]]>
-</INLINE>
-</FILE>
-
-<FILE Name="/boot/config/plugins/sabnzbd/sabnzbd.cfg">
-<INLINE>
-<![CDATA[
-# SABnzbd configuration:
-SERVICE="disable"
-BETA="no"
-INSTALLDIR="/usr/local/sabnzbd"
-DATADIR="/usr/local/sabnzbd"
-RUNAS="nobody"
-PLG_STORAGESIZE="yes"
-PLG_DATACHECK="yes"
 ]]>
 </INLINE>
 </FILE>


### PR DESCRIPTION
Using latest version (2.4) of plugin, when installed onto system where there was never a preexisting /boot/config/plugins/sabnzbd/sabnzbd.cfg file, the checkconfig code in plugin causes a sabnzbd.cfg file to be created with just the new field (in this case BETA).  Subsequent config file creation fails due to existing file.  Result is that in webgui, many fields are empty.
