### PR TITLE
Updated Unrar to Version 5.0.14

### DIFF
--- a/sabnzbd_unplugged.plg
+++ b/sabnzbd_unplugged.plg
@@ -30,9 +30,9 @@ I have probably missed some credits here, not intentional but I do not have a pe
 <URL>http://slackware.cs.utah.edu/pub/slackware/slackware-13.37/slackware/ap/sqlite-3.7.5-i486-1.txz</URL>
 <MD5>6786d3764cb294ecb71cdd24e6d171d1</MD5>
 </FILE>
-<FILE Name="/boot/packages/unrar-4.2.4-i486-1alien.tgz" Run="upgradepkg --install-new">
-<URL>http://www.slackware.com/~alien/slackbuilds/unrar/pkg/13.37/unrar-4.2.4-i486-1alien.tgz</URL>
-<MD5>26b4b3d9a10cb8bf7a4dd746de30e80b</MD5>
+<FILE Name="/boot/packages/unrar-5.0.14-i486-1cf.txz" Run="upgradepkg --install-new">
+<URL>http://dl.bintray.com/darkside401/unrar5-unraid/unrar-5.0.14-i486-1cf.txz</URL>
+<MD5>0e93fb29caab9db35d3ebfbf455ffc50</MD5>
 </FILE>
 <FILE Name="/boot/packages/infozip-6.0-i486-1.txz" Run="upgradepkg --install-new">
 <URL>http://slackware.cs.utah.edu/pub/slackware/slackware-13.37/slackware/a/infozip-6.0-i486-1.txz</URL>


### PR DESCRIPTION
I have updated Unrar to Version 5.0.14. Compiled on Slackware 13.37 using Corrado Francos Slackbuild (https://github.com/conraid/SlackBuilds).
Package is hosted on Bintray, because it was the easiest solution.
