### PR TITLE
Update to UnRAR 5 package

### DIFF
--- a/sabnzbd_unplugged.plg
+++ b/sabnzbd_unplugged.plg
@@ -30,9 +30,9 @@ I have probably missed some credits here, not intentional but I do not have a pe
 <URL>http://slackware.cs.utah.edu/pub/slackware/slackware-13.37/slackware/ap/sqlite-3.7.5-i486-1.txz</URL>
 <MD5>6786d3764cb294ecb71cdd24e6d171d1</MD5>
 </FILE>
-<FILE Name="/boot/packages/unrar-4.2.4-i486-1alien.tgz" Run="upgradepkg --install-new">
-<URL>http://www.slackware.com/~alien/slackbuilds/unrar/pkg/13.37/unrar-4.2.4-i486-1alien.tgz</URL>
-<MD5>26b4b3d9a10cb8bf7a4dd746de30e80b</MD5>
+<FILE Name="/boot/packages/unrar-5.0.14-i486-1sl.txz" Run="upgradepkg --install-new">
+<URL>http://slackware.org.uk/slacky/slackware-14.1/system/unrar/5.0.14/unrar-5.0.14-i486-1sl.txz</URL>
+<MD5>e45de6924d6a78fc954afa91b059e47d</MD5>
 </FILE>
 <FILE Name="/boot/packages/infozip-6.0-i486-1.txz" Run="upgradepkg --install-new">
 <URL>http://slackware.cs.utah.edu/pub/slackware/slackware-13.37/slackware/a/infozip-6.0-i486-1.txz</URL>


### PR DESCRIPTION
Files compressed with UnRAR 5.x cannot be extracted with UnRAR 4.x causing some downloads to fail the extraction step. Updating the package to use the latest UnRAR for Slackware enables SABnzbd to extract all RAR archives whether they were compressed with 4.x or 5.x. This change has been tested for almost a year without any issues, time to make it official.
